### PR TITLE
feat: unify admin panel with Bootstrap tabs

### DIFF
--- a/NewLaravelProject/app/Http/Controllers/AdminPanelController.php
+++ b/NewLaravelProject/app/Http/Controllers/AdminPanelController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Comment;
+use App\Models\User;
+use App\Models\Advertisement;
+use Illuminate\Http\Request;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+class AdminPanelController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Display the unified admin panel with all admin functionalities.
+     */
+    public function index(Request $request)
+    {
+        // Check if user has admin access (either admin or townhall for comments)
+        if (!auth()->check() || (!auth()->user()->isAdmin() && !auth()->user()->isTownHall())) {
+            abort(403, 'Unauthorized access.');
+        }
+
+        $data = [];
+
+        // Load pending comments (if user is admin or townhall)
+        if (auth()->user()->isAdmin() || auth()->user()->isTownHall()) {
+            $data['comments'] = Comment::with(['user', 'festivity.locality'])
+                ->where('approved', false)
+                ->orderBy('created_at', 'desc')
+                ->get();
+        }
+
+        // Load users (admin only)
+        if (auth()->user()->isAdmin()) {
+            $data['users'] = User::with('locality')->get();
+        }
+
+        // Load advertisements (admin only)
+        if (auth()->user()->isAdmin()) {
+            $search = $request->get('search', '');
+            $sort = in_array($request->get('sort'), ['name', 'priority', 'active', 'created_at'], true) 
+                ? $request->get('sort') 
+                : 'created_at';
+            $direction = $request->get('direction') === 'asc' ? 'asc' : 'desc';
+
+            $query = Advertisement::with(['festivity', 'locality'])
+                ->premium()
+                ->when($search, function ($q) use ($search) {
+                    $q->where(function ($inner) use ($search) {
+                        $inner->where('name', 'like', "%{$search}%")
+                            ->orWhere('url', 'like', "%{$search}%");
+                    });
+                })
+                ->orderBy($sort, $direction);
+
+            $data['advertisements'] = $query->paginate(12)->withQueryString();
+            $data['search'] = $search;
+            $data['sort'] = $sort;
+            $data['direction'] = $direction;
+        }
+
+        return view('admin.panel', $data);
+    }
+}
+

--- a/NewLaravelProject/resources/views/admin/panel.blade.php
+++ b/NewLaravelProject/resources/views/admin/panel.blade.php
@@ -1,0 +1,105 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h1 class="display-6 fw-bold text-primary mb-0">
+            <i class="bi bi-shield-check me-2"></i>Admin Panel
+        </h1>
+    </x-slot>
+
+    <div class="container">
+        @php
+            $activeTab = request()->get('tab', 'comments');
+            // Determine which tabs to show based on user role
+            $showComments = auth()->user()->isAdmin() || auth()->user()->isTownHall();
+            $showUsers = auth()->user()->isAdmin();
+            $showAdvertisements = auth()->user()->isAdmin();
+            
+            // Set default tab if requested tab is not available
+            if ($activeTab === 'users' && !$showUsers) {
+                $activeTab = 'comments';
+            }
+            if ($activeTab === 'advertisements' && !$showAdvertisements) {
+                $activeTab = 'comments';
+            }
+            if ($activeTab === 'comments' && !$showComments) {
+                $activeTab = $showUsers ? 'users' : ($showAdvertisements ? 'advertisements' : 'comments');
+            }
+        @endphp
+
+        <!-- Bootstrap Tabs -->
+        <ul class="nav nav-tabs mb-4" id="adminTabs" role="tablist">
+            @if($showComments)
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link {{ $activeTab === 'comments' ? 'active' : '' }}" 
+                            id="comments-tab" 
+                            data-bs-toggle="tab" 
+                            data-bs-target="#comments" 
+                            type="button" 
+                            role="tab" 
+                            aria-controls="comments" 
+                            aria-selected="{{ $activeTab === 'comments' ? 'true' : 'false' }}">
+                        <i class="bi bi-chat-dots me-1"></i>Moderate Comments
+                    </button>
+                </li>
+            @endif
+            @if($showUsers)
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link {{ $activeTab === 'users' ? 'active' : '' }}" 
+                            id="users-tab" 
+                            data-bs-toggle="tab" 
+                            data-bs-target="#users" 
+                            type="button" 
+                            role="tab" 
+                            aria-controls="users" 
+                            aria-selected="{{ $activeTab === 'users' ? 'true' : 'false' }}">
+                        <i class="bi bi-people me-1"></i>Users
+                    </button>
+                </li>
+            @endif
+            @if($showAdvertisements)
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link {{ $activeTab === 'advertisements' ? 'active' : '' }}" 
+                            id="advertisements-tab" 
+                            data-bs-toggle="tab" 
+                            data-bs-target="#advertisements" 
+                            type="button" 
+                            role="tab" 
+                            aria-controls="advertisements" 
+                            aria-selected="{{ $activeTab === 'advertisements' ? 'true' : 'false' }}">
+                        <i class="bi bi-badge-ad me-1"></i>Advertisements
+                    </button>
+                </li>
+            @endif
+        </ul>
+
+        <!-- Tab Content -->
+        <div class="tab-content" id="adminTabsContent">
+            @if($showComments)
+                <div class="tab-pane fade {{ $activeTab === 'comments' ? 'show active' : '' }}" 
+                     id="comments" 
+                     role="tabpanel" 
+                     aria-labelledby="comments-tab">
+                    @include('admin.partials.comments')
+                </div>
+            @endif
+
+            @if($showUsers)
+                <div class="tab-pane fade {{ $activeTab === 'users' ? 'show active' : '' }}" 
+                     id="users" 
+                     role="tabpanel" 
+                     aria-labelledby="users-tab">
+                    @include('admin.partials.users')
+                </div>
+            @endif
+
+            @if($showAdvertisements)
+                <div class="tab-pane fade {{ $activeTab === 'advertisements' ? 'show active' : '' }}" 
+                     id="advertisements" 
+                     role="tabpanel" 
+                     aria-labelledby="advertisements-tab">
+                    @include('admin.partials.advertisements')
+                </div>
+            @endif
+        </div>
+    </div>
+</x-app-layout>
+

--- a/NewLaravelProject/resources/views/admin/partials/advertisements.blade.php
+++ b/NewLaravelProject/resources/views/admin/partials/advertisements.blade.php
@@ -1,0 +1,166 @@
+@if(session('success'))
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <i class="bi bi-check-circle me-2"></i>{{ session('success') }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+@endif
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h5 class="mb-0">Premium Advertisements</h5>
+    <a href="{{ route('advertisements.create') }}" class="btn btn-primary btn-sm">
+        <i class="bi bi-plus-circle me-1"></i>Nuevo Anuncio
+    </a>
+</div>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="GET" action="{{ route('admin.panel') }}" class="row g-3 align-items-end">
+            <input type="hidden" name="tab" value="advertisements">
+            <div class="col-md-10">
+                <label class="form-label fw-bold">Buscar</label>
+                <input type="text" name="search" class="form-control" placeholder="Nombre o URL"
+                       value="{{ $search ?? '' }}">
+            </div>
+            <div class="col-md-2 d-grid">
+                <button type="submit" class="btn btn-outline-primary mt-md-4">
+                    <i class="bi bi-search me-1"></i>Buscar
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="card">
+    <div class="table-responsive">
+        <table class="table align-middle mb-0">
+            <thead class="table-light">
+                @php
+                    $baseQuery = array_merge(request()->except(['page']), ['tab' => 'advertisements']);
+                    $sortLink = function (string $column) use ($baseQuery, $sort, $direction) {
+                        $nextDirection = ($sort === $column && $direction === 'asc') ? 'desc' : 'asc';
+                        return route('admin.panel', array_merge($baseQuery, [
+                            'sort' => $column,
+                            'direction' => $nextDirection,
+                        ]));
+                    };
+                    $sortIcon = function (string $column) use ($sort, $direction) {
+                        if ($sort !== $column) {
+                            return '<i class="bi bi-arrow-down-up text-muted small"></i>';
+                        }
+                        return $direction === 'asc'
+                            ? '<i class="bi bi-caret-up-fill text-primary small"></i>'
+                            : '<i class="bi bi-caret-down-fill text-primary small"></i>';
+                    };
+                @endphp
+                <tr>
+                    <th>Imagen</th>
+                    <th>
+                        <a href="{{ $sortLink('name') }}" class="text-decoration-none d-inline-flex align-items-center gap-1 text-dark">
+                            Nombre {!! $sortIcon('name') !!}
+                        </a>
+                    </th>
+                    <th>Contexto</th>
+                    <th>
+                        <a href="{{ $sortLink('priority') }}" class="text-decoration-none d-inline-flex align-items-center gap-1 text-dark">
+                            Prioridad {!! $sortIcon('priority') !!}
+                        </a>
+                    </th>
+                    <th>
+                        <a href="{{ $sortLink('active') }}" class="text-decoration-none d-inline-flex align-items-center gap-1 text-dark">
+                            Activo {!! $sortIcon('active') !!}
+                        </a>
+                    </th>
+                    <th>
+                        <a href="{{ $sortLink('created_at') }}" class="text-decoration-none d-inline-flex align-items-center gap-1 text-dark">
+                            Creado {!! $sortIcon('created_at') !!}
+                        </a>
+                    </th>
+                    <th class="text-end">Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($advertisements ?? [] as $ad)
+                    <tr>
+                        <td style="width: 120px;">
+                            @if($ad->image)
+                                <img src="{{ \Illuminate\Support\Str::startsWith($ad->image, ['http://', 'https://']) ? $ad->image : asset($ad->image) }}"
+                                     alt="{{ $ad->name }}"
+                                     class="img-fluid rounded"
+                                     style="max-height: 70px; object-fit: cover;">
+                            @else
+                                <div class="text-muted small">Sin imagen</div>
+                            @endif
+                        </td>
+                        <td>
+                            <div class="fw-semibold">{{ $ad->name }}</div>
+                            @if($ad->url)
+                                <a href="{{ $ad->url }}" target="_blank" rel="noopener" class="small text-muted">
+                                    {{ $ad->url }}
+                                </a>
+                            @endif
+                        </td>
+                        <td>
+                            <div class="small text-muted">
+                                @if($ad->festivity)
+                                    <div><i class="bi bi-calendar-event me-1"></i>{{ $ad->festivity->name }}</div>
+                                @endif
+                                @if($ad->locality)
+                                    <div><i class="bi bi-geo-alt me-1"></i>{{ $ad->locality->name }}</div>
+                                @endif
+                            </div>
+                        </td>
+                        <td>
+                            <span class="badge {{ $ad->priority === 'principal' ? 'bg-primary' : 'bg-secondary' }}">
+                                {{ ucfirst($ad->priority) }}
+                            </span>
+                        </td>
+                        <td>
+                            <form method="POST" action="{{ route('advertisements.toggle', $ad) }}">
+                                @csrf
+                                @method('PATCH')
+                                <input type="hidden" name="active" value="0">
+                                <div class="form-check form-switch">
+                                    <input type="checkbox" class="form-check-input" name="active" value="1"
+                                           onchange="this.form.submit()" {{ $ad->active ? 'checked' : '' }}>
+                                </div>
+                            </form>
+                        </td>
+                        <td>{{ $ad->created_at->format('d/m/Y') }}</td>
+                        <td class="text-end">
+                            <div class="d-flex gap-2 justify-content-end">
+                                <a href="{{ route('advertisements.edit', $ad) }}" class="btn btn-sm btn-outline-warning">
+                                    <i class="bi bi-pencil"></i>
+                                </a>
+                                <form method="POST" action="{{ route('advertisements.destroy', $ad) }}"
+                                      onsubmit="return confirm('¿Eliminar este anuncio?')">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">
+                                        <i class="bi bi-trash"></i>
+                                    </button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="7" class="text-center py-5">
+                            <i class="bi bi-badge-ad display-5 text-muted d-block mb-3"></i>
+                            <p class="mb-3 text-muted">No hay anuncios premium todavía.</p>
+                            <a href="{{ route('advertisements.create') }}" class="btn btn-primary">
+                                Crear primer anuncio
+                            </a>
+                        </td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    @if(isset($advertisements) && $advertisements->hasPages())
+        <div class="card-footer">
+            {{ $advertisements->links('pagination::bootstrap-5') }}
+        </div>
+    @endif
+</div>
+

--- a/NewLaravelProject/resources/views/admin/partials/comments.blade.php
+++ b/NewLaravelProject/resources/views/admin/partials/comments.blade.php
@@ -1,0 +1,123 @@
+@if(session('success'))
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <i class="bi bi-check-circle me-2"></i>{{ session('success') }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+@endif
+
+@if(isset($comments) && $comments->count() > 0)
+    <div class="row g-4">
+        @foreach($comments as $comment)
+            <div class="col-12">
+                <div class="card shadow-sm">
+                    <div class="card-header bg-light">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <h5 class="card-title mb-1">
+                                    <i class="bi bi-person-circle me-2"></i>{{ $comment->user->name }}
+                                </h5>
+                                <p class="text-muted small mb-1">
+                                    <i class="bi bi-envelope me-1"></i>{{ $comment->user->email }}
+                                </p>
+                                <p class="text-muted small mb-0">
+                                    <i class="bi bi-clock me-1"></i>{{ $comment->created_at->format('M j, Y g:i A') }}
+                                </p>
+                            </div>
+                            <div class="d-flex gap-2">
+                                <form method="POST" action="{{ route('comments.approve', $comment) }}" class="d-inline">
+                                    @csrf
+                                    @method('PATCH')
+                                    <button type="submit" class="btn btn-success btn-sm">
+                                        <i class="bi bi-check-circle me-1"></i>Approve
+                                    </button>
+                                </form>
+                                <form method="POST" action="{{ route('comments.reject', $comment) }}" class="d-inline">
+                                    @csrf
+                                    @method('PATCH')
+                                    <button type="submit" class="btn btn-danger btn-sm"
+                                            onclick="return confirm('Are you sure you want to reject this comment?')">
+                                        <i class="bi bi-x-circle me-1"></i>Reject
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <h6 class="fw-bold text-primary mb-2">
+                                <i class="bi bi-calendar-event me-2"></i>Festivity:
+                            </h6>
+                            <a href="{{ route('festivities.show', $comment->festivity) }}" class="btn btn-outline-primary btn-sm">
+                                <i class="bi bi-eye me-1"></i>{{ $comment->festivity->name }} - {{ $comment->festivity->locality->name }}
+                            </a>
+                        </div>
+                        
+                        <div class="bg-light rounded p-3">
+                            <h6 class="fw-bold text-dark mb-3">
+                                <i class="bi bi-chat-quote me-2"></i>Comentario:
+                            </h6>
+                            <div class="row g-3">
+                                @if($comment->photo)
+                                    <div class="col-auto">
+                                        <div class="mb-2">
+                                            <small class="text-muted d-block mb-1">
+                                                <i class="bi bi-image me-1"></i>Foto adjunta:
+                                            </small>
+                                        </div>
+                                        <img src="{{ asset($comment->photo) }}" 
+                                             alt="Foto del comentario de {{ $comment->user->name }}" 
+                                             class="rounded shadow-sm"
+                                             style="width: 120px; height: 120px; object-fit: cover; cursor: pointer;"
+                                             onclick="openImageModal('{{ asset($comment->photo) }}')"
+                                             onerror="this.style.display='none';">
+                                    </div>
+                                @endif
+                                <div class="col">
+                                    <p class="mb-0 text-dark">{{ $comment->content }}</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+@else
+    <div class="text-center py-5">
+        <div class="card">
+            <div class="card-body py-5">
+                <i class="bi bi-chat-dots display-1 text-muted"></i>
+                <h3 class="mt-3 text-muted">No Pending Comments</h3>
+                <p class="text-muted">All comments have been moderated. Check back later for new submissions.</p>
+                <a href="{{ route('home') }}" class="btn btn-primary btn-custom mt-3">
+                    <i class="bi bi-house me-1"></i>Back to Home
+                </a>
+            </div>
+        </div>
+    </div>
+@endif
+
+<!-- Modal para ver imagen en grande -->
+<div class="modal fade" id="imageModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Imagen del comentario</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body text-center">
+                <img id="modal-image" src="" alt="Imagen ampliada" class="img-fluid">
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    function openImageModal(imageSrc) {
+        document.getElementById('modal-image').src = imageSrc;
+        const modal = new bootstrap.Modal(document.getElementById('imageModal'));
+        modal.show();
+    }
+</script>
+

--- a/NewLaravelProject/resources/views/admin/partials/users.blade.php
+++ b/NewLaravelProject/resources/views/admin/partials/users.blade.php
@@ -1,0 +1,82 @@
+@if(session('success'))
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <i class="bi bi-check-circle me-2"></i>{{ session('success') }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+@endif
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h5 class="mb-0">User Management</h5>
+    <a href="{{ route('users.create') }}" class="btn btn-primary btn-sm">
+        <i class="bi bi-plus-circle me-1"></i>Crear Usuario
+    </a>
+</div>
+
+@if(isset($users) && $users->count() > 0)
+    <div class="row">
+        @foreach($users as $user)
+            <div class="col-lg-4 col-md-6 mb-4">
+                <div class="card h-100 shadow-sm">
+                    <div class="card-body d-flex flex-column">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="avatar bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-3" style="width: 50px; height: 50px;">
+                                <i class="bi bi-person-fill"></i>
+                            </div>
+                            <div>
+                                <h5 class="card-title mb-0">{{ $user->name }}</h5>
+                                <p class="text-muted mb-0">{{ $user->email }}</p>
+                            </div>
+                        </div>
+                        
+                        <div class="mb-3">
+                            <span class="badge bg-secondary me-2">{{ ucfirst($user->role) }}</span>
+                            @if($user->isVisitor())
+                                <span class="badge bg-warning me-2">{{ $user->getRankIcon() }} {{ $user->getRankDisplayName() }}</span>
+                                <span class="badge bg-info">{{ $user->points }} pts</span>
+                            @endif
+                        </div>
+                        
+                        @if($user->locality)
+                            <p class="text-muted small mb-3">
+                                <i class="bi bi-geo-alt me-1"></i>{{ $user->locality->name }}
+                            </p>
+                        @endif
+                        
+                        <div class="mt-auto">
+                            <div class="d-flex gap-2">
+                                <a href="{{ route('users.show', $user) }}" class="btn btn-outline-primary btn-sm flex-fill">
+                                    <i class="bi bi-eye me-1"></i>Ver
+                                </a>
+                                <a href="{{ route('users.edit', $user) }}" class="btn btn-outline-warning btn-sm flex-fill">
+                                    <i class="bi bi-pencil me-1"></i>Editar
+                                </a>
+                                <form action="{{ route('users.destroy', $user) }}" method="POST" class="flex-fill" 
+                                      onsubmit="return confirm('¿Estás seguro de que quieres eliminar este usuario?')">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-outline-danger btn-sm w-100">
+                                        <i class="bi bi-trash me-1"></i>Eliminar
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+@else
+    <div class="text-center py-5">
+        <div class="card border-0">
+            <div class="card-body">
+                <i class="bi bi-people display-1 text-muted mb-3"></i>
+                <h3 class="card-title">No hay usuarios</h3>
+                <p class="card-text text-muted">Comienza creando el primer usuario del sistema.</p>
+                <a href="{{ route('users.create') }}" class="btn btn-primary">
+                    <i class="bi bi-plus-circle me-1"></i>Crear Usuario
+                </a>
+            </div>
+        </div>
+    </div>
+@endif
+

--- a/NewLaravelProject/resources/views/layouts/navigation.blade.php
+++ b/NewLaravelProject/resources/views/layouts/navigation.blade.php
@@ -28,15 +28,7 @@
                 @auth
                     @if(auth()->user()->isAdmin() || auth()->user()->isTownHall())
                         <li class="nav-item">
-                            <a class="nav-link {{ request()->routeIs('comments.*') ? 'active' : '' }}" href="{{ route('comments.pending') }}">Moderate Comments</a>
-                        </li>
-                    @endif
-                    @if(auth()->user()->isAdmin())
-                        <li class="nav-item">
-                            <a class="nav-link {{ request()->routeIs('users.*') ? 'active' : '' }}" href="{{ route('users.index') }}">Users</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link {{ request()->routeIs('advertisements.*') ? 'active' : '' }}" href="{{ route('advertisements.index') }}">Advertisements</a>
+                            <a class="nav-link {{ request()->routeIs('admin.*') || request()->routeIs('comments.*') || request()->routeIs('users.*') || request()->routeIs('advertisements.*') ? 'active' : '' }}" href="{{ route('admin.panel') }}">Admin</a>
                         </li>
                     @endif
                 @endauth

--- a/NewLaravelProject/routes/web.php
+++ b/NewLaravelProject/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AdvertisementController;
+use App\Http\Controllers\AdminPanelController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\LocalityController;
@@ -84,6 +85,9 @@ Route::middleware(['auth', 'legal.accepted'])->group(function () {
     // Premium advertisements admin
     Route::resource('advertisements', AdvertisementController::class)->except(['show']);
     Route::patch('advertisements/{advertisement}/toggle-active', [AdvertisementController::class, 'toggle'])->name('advertisements.toggle');
+
+    // Unified admin panel
+    Route::get('admin-panel', [AdminPanelController::class, 'index'])->name('admin.panel');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
- Replace three separate admin navbar links with single 'Admin' link
- Create unified AdminPanelController to load all admin data
- Add admin panel route (/admin-panel)
- Create partial views for comments, users, and advertisements
- Implement Bootstrap tabs in unified admin panel view
- Preserve all existing functionality and routes
- Maintain access control (admin/townhall permissions)